### PR TITLE
Proposed fix to error - find_nearest_dark_exposure

### DIFF
--- a/notebooks/05-03-Calibrating-the-flats.ipynb
+++ b/notebooks/05-03-Calibrating-the-flats.ipynb
@@ -80,7 +80,7 @@
     "        np.abs(image.header['exptime'] - closest_dark_exposure) > tolerance):\n",
     "        \n",
     "        raise RuntimeError('Closest dark exposure time is {} for flat of exposure '\n",
-    "                           'time {}.'.format(closest_dark_exposure, a_flat.header['exptime']))\n",
+    "                           'time {}.'.format(closest_dark_exposure, image.header['exptime']))\n",
     "        \n",
     "    \n",
     "    return closest_dark_exposure"


### PR DESCRIPTION
In the function find_nearest_dark_exposure(image, dark_exposure_times, tolerance=0.5), there is an error in the line before the return statement.

Original line:
```
raise RuntimeError('Closest dark exposure time is {} for flat of exposure '
                           'time {}.'.format(closest_dark_exposure, a_flat.header['EXPTIME']))
```

Error corrected:
```
raise RuntimeError('Closest dark exposure time is {} for flat of exposure '
                           'time {}.'.format(closest_dark_exposure, image.header['EXPTIME']))
```

Basically, the error is that 'a_flat' should be 'image'.