### PR TITLE
Fix handling of None as random seed

### DIFF
--- a/notebooks/01-03-Construction-of-an-artificial-but-realistic-image.ipynb
+++ b/notebooks/01-03-Construction-of-an-artificial-but-realistic-image.ipynb
@@ -57,9 +57,12 @@
     "# Set up the random number generator, allowing a seed to be set from the environment\n",
     "seed = os.getenv('GUIDE_RANDOM_SEED', None)\n",
     "\n",
+    "if seed is not None:\n",
+    "    seed = int(seed)\n",
+    "    \n",
     "# This is the generator to use for any image component which changes in each image, e.g. read noise\n",
     "# or Poisson error\n",
-    "noise_rng = np.random.default_rng(int(seed))"
+    "noise_rng = np.random.default_rng(seed)"
    ]
   },
   {

--- a/notebooks/01-06-Image-combination.ipynb
+++ b/notebooks/01-06-Image-combination.ipynb
@@ -77,9 +77,12 @@
     "# Set up the random number generator, allowing a seed to be set from the environment\n",
     "seed = os.getenv('GUIDE_RANDOM_SEED', None)\n",
     "\n",
+    "if seed is not None:\n",
+    "    seed = int(seed)\n",
+    "    \n",
     "# This is the generator to use for any image component which changes in each image, e.g. read noise\n",
     "# or Poisson error\n",
-    "noise_rng = np.random.default_rng(int(seed))"
+    "noise_rng = np.random.default_rng(seed)"
    ]
   },
   {

--- a/notebooks/image_sim.py
+++ b/notebooks/image_sim.py
@@ -7,11 +7,14 @@ from photutils.datasets import (make_random_gaussians_table,
                                 make_gaussian_sources_image)
 from photutils.aperture import EllipticalAperture
 
-# To use a sesed, set it in the environment. Useful for minimuizing changes when
+# To use a seed, set it in the environment. Useful for minimizing changes when
 # publishing the book.
 seed = os.getenv('GUIDE_RANDOM_SEED', None)
 
-default_rng = np.random.default_rng(int(seed))
+if seed is not None:
+    seed = int(seed)
+    
+default_rng = np.random.default_rng(seed)
 
 
 def read_noise(image, amount, gain=1):


### PR DESCRIPTION
The previous iteration of this failed if the seed was `None` because `None` cannot be converted to an int.