### PR TITLE
Change multi dimensional index to use tuple to fix deprecation warning

### DIFF
--- a/notebooks/01-03-Construction-of-an-artificial-but-realistic-image.ipynb
+++ b/notebooks/01-03-Construction-of-an-artificial-but-realistic-image.ipynb
@@ -345,7 +345,7 @@
     "        \n",
     "        hot_current = 10000 * current\n",
     "        \n",
-    "        dark_im[[hot_y, hot_x]] = hot_current * exposure_time / gain\n",
+    "        dark_im[(hot_y, hot_x)] = hot_current * exposure_time / gain\n",
     "    return dark_im"
    ]
   },
@@ -649,7 +649,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -663,7 +663,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.5"
+   "version": "3.9.9"
   }
  },
  "nbformat": 4,

--- a/notebooks/01-03-Construction-of-an-artificial-but-realistic-image.ipynb
+++ b/notebooks/01-03-Construction-of-an-artificial-but-realistic-image.ipynb
@@ -649,7 +649,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "Python 3",
    "language": "python",
    "name": "python3"
   },
@@ -663,7 +663,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.9"
+   "version": "3.8.5"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Fix Dark Current generator code to remove a future warning 

```
FutureWarning: Using a non-tuple sequence for multidimensional indexing is deprecated; use `arr[tuple(seq)]` instead of `arr[seq]`. In the future this will be interpreted as an array index, `arr[np.array(seq)]`, which will result either in an error or a different result.
  dark_im[[hot_y, hot_x]] = hot_current * exposure_time / gain
```