### PR TITLE
Fix error with make_random_gaussians_table parameter

### DIFF
--- a/notebooks/01-03-Construction-of-an-artificial-but-realistic-image.ipynb
+++ b/notebooks/01-03-Construction-of-an-artificial-but-realistic-image.ipynb
@@ -566,7 +566,7 @@
     "                  ('theta', [0, 2*np.pi])])\n",
     "\n",
     "    sources = make_random_gaussians_table(number, params,\n",
-    "                                          random_state=12345)\n",
+    "                                          seed=12345)\n",
     "    \n",
     "    star_im = make_gaussian_sources_image(image.shape, sources)\n",
     "    \n",


### PR DESCRIPTION
`make_random_gaussians_table` seems to have modified the signature and `random_state` is now called `seed`