### PR TITLE
Update 01-06-Image-combination.ipynb

### DIFF
--- a/notebooks/01-06-Image-combination.ipynb
+++ b/notebooks/01-06-Image-combination.ipynb
@@ -427,7 +427,7 @@
     "a value is from the typical value. The [median absolute deviation](https://en.wikipedia.org/wiki/Median_absolute_deviation), or MAD,\n",
     "of a set of points $x$ is defined by:\n",
     "$$\n",
-    "MAD = \\frac{1}{N}\\sum_{i=0}^N |x_i - \\text{median}(x)|.\n",
+    "\\text{MAD} = \\text{median}\\big( x_i - \\text{median}(x) \\big).\n",
     "$$\n",
     "This is a measure of the typical absolute distance from the median of the set of\n",
     "values. The MAD is not directly equivalent to the standard deviation. The\n",


### PR DESCRIPTION
I think there is a mistake in the 01-06-Image-combination.ipynb notebook when explaining how the median absolute deviation is computed. The quoted equation:

$$
MAD = \frac{1}{N}\sum_{i=0}^N |x_i - \text{median}(x)|.
$$

is computing the mean (not de median) of the $x_i - \text{median}(x)$ values. The correct expression should be

$$
\text{MAD} = \text{median}\big( x_i - \text{median}(x)\big )
$$