### PR TITLE
Addresses #353 by handling OSError when downloading the data files

### DIFF
--- a/notebooks/download_data.py
+++ b/notebooks/download_data.py
@@ -1,33 +1,40 @@
 from pathlib import Path
+import shutil
 import tarfile
 
 from astropy.utils.data import download_file
+
+def move(p : Path, dest : str):
+    try:
+        p.rename(dest)
+    except OSError:
+        shutil.move(p, dest)
 
 # Get single images
 url = 'https://zenodo.org/record/3320113/files/combined_bias_100_images.fit.bz2?download=1'
 download = download_file(url, show_progress=True)
 p = Path(download)
-p.rename('combined_bias_100_images.fit.bz2')
+move(p, './combined_bias_100_images.fit.bz2')
 
 url = 'https://zenodo.org/record/3312535/files/dark-test-0002d1000.fit.bz2?download=1'
 download = download_file(url, show_progress=True)
 p = Path(download)
-p.rename('dark-test-0002d1000.fit.bz2')
+move(p,'dark-test-0002d1000.fit.bz2')
 
 url = 'https://zenodo.org/record/5931364/files/single_bias_thermoelectric.fit.bz2?download=1'
 download = download_file(url, show_progress=True)
 p = Path(download)
-p.rename('single_bias_thermoelectric.fit.bz2')
+move(p,'single_bias_thermoelectric.fit.bz2')
 
 url = 'https://zenodo.org/record/3332818/files/combined_dark_300.000.fits.bz2?download=1'
 download = download_file(url, show_progress=True)
 p = Path(download)
-p.rename('combined_dark_300.000.fits.bz2')
+move(p,'combined_dark_300.000.fits.bz2')
 
 url = 'https://zenodo.org/record/4302262/files/combined_dark_exposure_1000.0.fit.bz2?download=1'
 download = download_file(url, show_progress=True)
 p = Path(download)
-p.rename('combined_dark_exposure_1000.0.fit.bz2')
+move(p,'combined_dark_exposure_1000.0.fit.bz2')
 
 # Get the tarball for the smaller example and extract it
 url = 'https://zenodo.org/record/3254683/files/example-cryo-LFC.tar.bz2?download=1'


### PR DESCRIPTION
The `OSError` occurs when the download destination is on a different file system than the /tmp directory of the OS because pathlib.Path.rename() is used to move the file into its final destination, which throws `OSError` when renaming across different file systems. The change proposed here catches the exception and uses `shutil.move` to fix this.