### PR TITLE
MNT: upgrade upload/download-artifact GitHub actions

### DIFF
--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -74,7 +74,7 @@ jobs:
         jb build .
 
     - name: Upload HTML
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: rendered-book-sha-${{ github.sha }}
         path: |
@@ -92,7 +92,7 @@ jobs:
           if [[ "${{ github.ref }}" == 'refs/heads/main' ]]; then VERSION_NUMBER=dev; fi
           echo "VERSION_NUMBER=$VERSION_NUMBER" >> $GITHUB_ENV
       - name: Download artifact
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: rendered-book-sha-${{ github.sha }}
           path: dev


### PR DESCRIPTION
Hi, version 4 of upload-artifact and download-artifact were recently released.
Staying on old version is not viable long term because GitHub will sooner or later drop support for the old versions of node that these depend on.
Since migration to v4 is not as straightfoward as bumping the version number, I'm helping all astropy-related packages byt manually performing the necessary changes.

(in this specific case it is actually trivial, I'm just doing them all at once so no reason to skip this repo)
