### PR TITLE
Update workflow channel

### DIFF
--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -37,14 +37,17 @@ jobs:
       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
       with:
         fetch-depth: 0
+
     - name: Setup Miniconda
       uses: conda-incubator/setup-miniconda@d2e6a045a86077fb6cad6f5adf368e9076ddaa8d  # v3.1.0
       with:
-        python-version: ${{ matrix.python }}
-        mamba-version: "*"
-        channels: astropy, conda-forge, defaults
-        channel-priority: true
+        miniforge-version: latest
+        use-mamba: true
         auto-update-conda: true
+        channels: conda-forge
+        python-version: ${{ matrix.python }}
+        activate-environment: mamba
+
     - name: Install base dependencies
       shell: bash -l {0}
       run: |
@@ -53,6 +56,7 @@ jobs:
         python -m pip install lxml_html_clean
         conda info -e
         # python -m pip install jupyter-book==0.12.1
+
     - name: Cache
       id: cache
       uses: actions/cache@6849a6489940f00c2f30c0fb92c6274307ccb58a  # v4.1.2
@@ -88,18 +92,20 @@ jobs:
     name: Deploy
     runs-on: ubuntu-latest
     needs: build_book
-    if: ${{ github.ref == 'refs/heads/main' || contains(github.ref, 'tags') }}
+    if: ${{ github.event_name }} == 'push'
     steps:
       - name: Set version number
         run: |
           VERSION_NUMBER=${GITHUB_REF#refs/tags/}
           if [[ "${{ github.ref }}" == 'refs/heads/main' ]]; then VERSION_NUMBER=dev; fi
           echo "VERSION_NUMBER=$VERSION_NUMBER" >> $GITHUB_ENV
+
       - name: Download artifact
         uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
         with:
           name: rendered-book-sha-${{ github.sha }}
           path: dev
+
       - name: Deploy pages
         uses: peaceiris/actions-gh-pages@4f9cc6602d3f66b9c108549d475ec49e8ef4d45e  # v4.0.0
         with:

--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -8,6 +8,7 @@ on:
   push:
     branches:
       - main  # GitHub now defaults to 'main' as the name of the primary branch. Change this as needed.
+      - update-workflow-channel
     tags: # run CI if specific tags are pushed
       - '[0-9]+.[0-9]+.[0-9]+[a-z0-9]*'  # pre-releases -- note that brackets only
                                          # match single character, and that * does
@@ -40,11 +41,13 @@ jobs:
       uses: conda-incubator/setup-miniconda@d2e6a045a86077fb6cad6f5adf368e9076ddaa8d  # v3.1.0
       with:
         python-version: ${{ matrix.python }}
+        mamba-version: "*"
+        channels: astropy, conda-forge, defaults
+        channel-priority: true
         auto-update-conda: true
     - name: Install base dependencies
       shell: bash -l {0}
       run: |
-        conda install -c conda-forge mamba
         mamba install --quiet -c conda-forge astroquery ccdproc photutils sphinx sphinxcontrib-bibtex jupyter-book=0.13.2
         conda list
         python -m pip install lxml_html_clean

--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -8,7 +8,6 @@ on:
   push:
     branches:
       - main  # GitHub now defaults to 'main' as the name of the primary branch. Change this as needed.
-      - update-workflow-channel
     tags: # run CI if specific tags are pushed
       - '[0-9]+.[0-9]+.[0-9]+[a-z0-9]*'  # pre-releases -- note that brackets only
                                          # match single character, and that * does
@@ -92,7 +91,7 @@ jobs:
     name: Deploy
     runs-on: ubuntu-latest
     needs: build_book
-    if: ${{ github.event_name }} == 'push'
+    if: ${{ github.ref == 'refs/heads/main' || contains(github.ref, 'tags') }}
     steps:
       - name: Set version number
         run: |

--- a/notebooks/00-00-Preface.ipynb
+++ b/notebooks/00-00-Preface.ipynb
@@ -138,6 +138,7 @@
     "+ Kris Stern\n",
     "+ Thomas Stibor\n",
     "+ Sarah Tuttle\n",
+    "+ Steve Marshall\n",
     "\n",
     "If you have provided feedback and are not listed above, we apologize -- please\n",
     "[open an issue here](https://github.com/astropy/ccd-reduction-and-photometry-guide/issues/new) so we can fix it."


### PR DESCRIPTION
This commit fixes #388 

This updates the Miniconda installer to point to the Miniforge releases:

https://github.com/conda-forge/miniforge

- Conda uses libmamba as the default solver version since the release of Conda 23.10.0 in November 2023
- Miniconda started shipping conda-libmamba-solver in July 2023, Miniforge followed suit and started shipping it too in August.
- Miniconda uses conda-forge exclusively; which means it uses the BSD-3 licenses instead of commercial Anaconda defaults

Successful build can be seen in fork, here:

https://github.com/marshast/ccd-reduction-and-photometry-guide/actions/runs/13331195310